### PR TITLE
feat: add settings confirmation modal

### DIFF
--- a/geode-cracker/src/Settings/Components/SettingsConfirmation.css
+++ b/geode-cracker/src/Settings/Components/SettingsConfirmation.css
@@ -1,0 +1,47 @@
+.settingsSection__confirmationSection{
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 100;
+
+    width: 100vw;
+    height: 100vh;
+
+    background-color: RGBA(0, 0, 0, 30%);
+}
+
+.settingsSection__confirmationSection__modal{
+    position: relative;
+    top: 50vh;
+    transform: translate(0, -50%);
+
+    min-width: 30rem;
+    max-width: 38rem;
+
+    margin: 0 auto;
+    padding: 1rem;
+
+    border-radius: 1rem;
+    background-color: var(--banner-background-light-color);
+}
+
+.settingsSection__confirmationSection__modal__title{
+    margin-bottom: 3rem;
+    padding: 1rem;
+
+    text-align: center;
+    font-size: 2.4rem;
+    font-weight: bold;
+}
+
+.settingsSection__confirmationSection__modal__choice{
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 3rem;
+}
+
+.settingsSection__confirmationSection__modal__choice__button{
+    width: 15rem;
+    height: 4.5rem;
+    font-size: 2rem;
+}

--- a/geode-cracker/src/Settings/Components/SettingsConfirmation.js
+++ b/geode-cracker/src/Settings/Components/SettingsConfirmation.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import './SettingsConfirmation.css'
+
+class SettingsConfirmation extends React.Component{
+    state = {
+        title: "Wil je opnieuw beginnen?",
+        text_button_left: "Nee",
+        text_button_right: "Ja"
+    }
+
+    render(){
+        return(
+            <section class="settingsSection__confirmationSection">
+                <article class="settingsSection__confirmationSection__modal">
+                    <h1 class="settingsSection__confirmationSection__modal__title">{this.state.title}</h1>
+                    <section class="settingsSection__confirmationSection__modal__choice">
+                        <button class="settingsSection__confirmationSection__modal__choice__button button button--green">{this.state.text_button_left}</button>
+                        <button class="settingsSection__confirmationSection__modal__choice__button button button--red">{this.state.text_button_right}</button>
+                    </section>
+                </article>
+            </section>
+        )
+    }
+}
+
+export default SettingsConfirmation;

--- a/geode-cracker/src/Settings/Components/SettingsConfirmation.js
+++ b/geode-cracker/src/Settings/Components/SettingsConfirmation.js
@@ -12,7 +12,7 @@ class SettingsConfirmation extends React.Component{
         return(
             <section class="settingsSection__confirmationSection">
                 <article class="settingsSection__confirmationSection__modal">
-                    <h1 class="settingsSection__confirmationSection__modal__title">{this.state.title}</h1>
+                    <h2 class="settingsSection__confirmationSection__modal__title">{this.state.title}</h2>
                     <section class="settingsSection__confirmationSection__modal__choice">
                         <button class="settingsSection__confirmationSection__modal__choice__button button button--green">{this.state.text_button_left}</button>
                         <button class="settingsSection__confirmationSection__modal__choice__button button button--red">{this.state.text_button_right}</button>

--- a/geode-cracker/src/Settings/Settings.js
+++ b/geode-cracker/src/Settings/Settings.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import './Settings.css';
+import SettingsConfirmation from './Components/SettingsConfirmation';
 import Switch from '@mui/material/Switch';
 
 class Settings extends React.Component{
@@ -16,6 +17,7 @@ class Settings extends React.Component{
     render(){
         return(
             <section class="settingsSection">
+                <SettingsConfirmation />
                 <h1 class="settingsSection__heading">{this.state.settings}</h1>
                 <article class="settingsSection__languages">
                     <button class={"settingsSection__languages__button button button--green" + this.state.dutch}>Nederlands</button>


### PR DESCRIPTION
# Feature
- adds a SettingsConfirmation component to the Settings page'
Note: The font does not work in this version of the app, this is a known issue
![image](https://user-images.githubusercontent.com/74965312/205493909-1032ec1c-b48c-4851-bc3d-ad782ce770db.png)