### PR TITLE
feat: add settings open and close functionalities

### DIFF
--- a/geode-cracker/package-lock.json
+++ b/geode-cracker/package-lock.json
@@ -18,6 +18,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.4.3",
         "react-scripts": "5.0.1",
+        "sass": "^1.56.1",
         "web-vitals": "^2.1.4"
       }
     },
@@ -9365,6 +9366,11 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -15409,6 +15415,22 @@
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-13.0.0.tgz",
       "integrity": "sha512-ZRwKbh/eQ6w9vmTjkuG0Ioi3HBwPFce0O+v//ve+aOq1oeCy7jMV2qzzAlpsNuqpqCBjjriM1lbtZbF/Q8jVyA=="
+    },
+    "node_modules/sass": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.56.1.tgz",
+      "integrity": "sha512-VpEyKpyBPCxE7qGDtOcdJ6fFbcpOM+Emu7uZLxVrkX8KVU/Dp5UF7WLvzqRuUhB6mqqQt1xffLoG+AndxTZrCQ==",
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/sass-loader": {
       "version": "12.6.0",
@@ -24262,6 +24284,11 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.16.tgz",
       "integrity": "sha512-qenGE7CstVm1NrHQbMh8YaSzTZTFNP3zPqr3YU0S0UY441j4bJTg4A2Hh5KAhwgaiU6ZZ1Ar6y/2f4TblnMReQ=="
     },
+    "immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -28429,6 +28456,16 @@
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-13.0.0.tgz",
       "integrity": "sha512-ZRwKbh/eQ6w9vmTjkuG0Ioi3HBwPFce0O+v//ve+aOq1oeCy7jMV2qzzAlpsNuqpqCBjjriM1lbtZbF/Q8jVyA=="
+    },
+    "sass": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.56.1.tgz",
+      "integrity": "sha512-VpEyKpyBPCxE7qGDtOcdJ6fFbcpOM+Emu7uZLxVrkX8KVU/Dp5UF7WLvzqRuUhB6mqqQt1xffLoG+AndxTZrCQ==",
+      "requires": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      }
     },
     "sass-loader": {
       "version": "12.6.0",

--- a/geode-cracker/src/App.js
+++ b/geode-cracker/src/App.js
@@ -16,8 +16,9 @@ function App() {
   return (
     <Router>
       <BannerTop />
+      <Settings />
       <Routes>
-        <Route path="/" >
+        <Route path="/">
           <Route index element={<h1>Home Pagina</h1>} />
           <Route path="syntax" element={[<Syntax />]} />
           <Route path="settings" element={[<Settings />]} />

--- a/geode-cracker/src/Banner/Banner.scss
+++ b/geode-cracker/src/Banner/Banner.scss
@@ -1,5 +1,5 @@
 .banner{
-  z-index: 2;
+  z-index: 10;
   width: 100vw;
   max-height: 20rem;
 

--- a/geode-cracker/src/Settings/Components/SettingsConfirmation.js
+++ b/geode-cracker/src/Settings/Components/SettingsConfirmation.js
@@ -10,12 +10,12 @@ class SettingsConfirmation extends React.Component{
 
     render(){
         return(
-            <section class="settingsSection__confirmationSection">
-                <article class="settingsSection__confirmationSection__modal">
-                    <h2 class="settingsSection__confirmationSection__modal__title">{this.state.title}</h2>
-                    <section class="settingsSection__confirmationSection__modal__choice">
-                        <button class="settingsSection__confirmationSection__modal__choice__button button button--green">{this.state.text_button_left}</button>
-                        <button class="settingsSection__confirmationSection__modal__choice__button button button--red">{this.state.text_button_right}</button>
+            <section class="settingsConfirmation">
+                <article class="settingsConfirmation__modal">
+                    <h2 class="settingsConfirmation__modal__title">{this.state.title}</h2>
+                    <section class="settingsConfirmation__modal__choice">
+                        <button class="settingsConfirmation__modal__choice__button button button--green" onClick={() => this.props.toggleComponent("confirmation_modal")}>{this.state.text_button_left}</button>
+                        <button class="settingsConfirmation__modal__choice__button button button--red" onClick={() => {this.props.toggleComponent("confirmation_modal"); this.props.toggleComponent("settings_modal"); this.props.settingsRestart();}}>{this.state.text_button_right}</button>
                     </section>
                 </article>
             </section>

--- a/geode-cracker/src/Settings/Components/SettingsConfirmation.scss
+++ b/geode-cracker/src/Settings/Components/SettingsConfirmation.scss
@@ -1,48 +1,46 @@
-.settingsSection{
-    &__confirmationSection{
-        position: absolute;
-        top: 0;
-        left: 0;
-        z-index: 100;
+.settingsConfirmation{
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 100;
 
-        width: 100vw;
-        height: 100vh;
+    width: 100vw;
+    height: 100vh;
 
-        background-color: RGBA(0, 0, 0, 30%);
+    background-color: RGBA(0, 0, 0, 30%);
 
-        &__modal{
-            position: relative;
-            top: 50vh;
-            transform: translate(0, -50%);
-        
-            min-width: 30rem;
-            max-width: 38rem;
-        
-            margin: 0 auto;
+    &__modal{
+        position: relative;
+        top: 50vh;
+        transform: translate(0, -50%);
+    
+        min-width: 30rem;
+        max-width: 38rem;
+    
+        margin: 0 auto;
+        padding: 1rem;
+    
+        border-radius: 1rem;
+        background-color: var(--banner-background-light-color);
+
+        &__title{
+            margin-bottom: 3rem;
             padding: 1rem;
         
-            border-radius: 1rem;
-            background-color: var(--banner-background-light-color);
+            text-align: center;
+            font-size: 2.4rem;
+            font-weight: bold;
+        }
 
-            &__title{
-                margin-bottom: 3rem;
-                padding: 1rem;
-            
-                text-align: center;
-                font-size: 2.4rem;
-                font-weight: bold;
-            }
+        &__choice{
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 3rem;
 
-            &__choice{
-                display: flex;
-                justify-content: space-between;
-                margin-bottom: 3rem;
-
-                &__button{
-                    width: 15rem;
-                    height: 4.5rem;
-                    font-size: 2rem;
-                }
+            &__button{
+                width: 15rem;
+                height: 4.5rem;
+                font-size: 2rem;
             }
         }
     }

--- a/geode-cracker/src/Settings/Components/SettingsMenu.js
+++ b/geode-cracker/src/Settings/Components/SettingsMenu.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import './SettingsMenu.scss';
+
+import Switch from '@mui/material/Switch';
+
+class SettingsMenu extends React.Component{
+    state = {
+        title: "Instellingen",
+        dutch: "",
+        english: "--inactive",
+        vibration: "Vibratie",
+        sound: "Geluid",
+        reset: "Opnieuw proberen",
+        icon_refresh_image_path: "/img/icon_refresh.png",
+    };
+
+    render(){
+        return(
+            <section class="settingsMenu">
+                <h1 class="settingsMenu__heading">{this.state.title}</h1>
+                <article class="settingsMenu__languages">
+                    <button class={"settingsMenu__languages__button button button--green" + this.state.dutch}>Nederlands</button>
+                    <button class={"settingsMenu__languages__button button button--green" + this.state.english}>English</button>
+                </article>
+                <article class="settingsMenu__toggles">
+                    <section class="settingsMenu__toggles__toggleOption">
+                        <h2 class="settingsMenu__toggles__toggleOption__text">{this.state.vibration}</h2>
+                        <Switch defaultChecked />
+                    </section>
+                    <hr class="settingsMenu__toggles__hr" />
+                    <section class="settingsMenu__toggles__toggleOption">
+                        <h2 class="settingsMenu__toggles__toggleOption__text">{this.state.sound}</h2>
+                        <Switch defaultChecked />
+                    </section>
+                    
+                </article>
+                <button class="settingsMenu__button button button--red" onClick={() => this.props.toggleComponent("confirmation_modal")}>
+                    {this.state.reset}
+                    <img class="settingsMenu__button__image" src={this.state.icon_refresh_image_path}/>
+                </button>
+            </section>
+        )
+    }
+}
+
+export default SettingsMenu;

--- a/geode-cracker/src/Settings/Components/SettingsMenu.scss
+++ b/geode-cracker/src/Settings/Components/SettingsMenu.scss
@@ -1,0 +1,57 @@
+.settingsMenu{
+    min-width: 30rem;
+    max-width: 38rem;
+    margin: 0 auto;
+    padding: 1rem;
+
+    &__heading{
+        margin-bottom: 2rem;
+
+        text-align: center;
+        color: var(--white-color);
+        font-size: 3.4rem;
+        font-weight: 1000;
+    }
+
+    &__languages{
+        display: flex;
+        justify-content: space-between;
+        
+        margin-bottom: 4rem;
+
+        &__button{
+            width: 45%;
+            height: 4.6rem;
+        }
+    }
+
+    &__toggles{
+        margin-bottom:4rem;
+
+        &__toggleOption{
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+
+            &__text{
+                color: var(--white-color);
+                font-size: 2rem;
+            }
+        }
+
+        &__hr{
+            margin: 1rem 0;
+        }
+    }
+
+    &__button{
+        width: 100%;
+        height: 4.6rem;
+
+        font-weight: 1000;
+
+        &__image{
+            height: 2rem;
+        }
+    }
+}

--- a/geode-cracker/src/Settings/Settings.js
+++ b/geode-cracker/src/Settings/Settings.js
@@ -1,44 +1,46 @@
 import React from 'react';
+import { withRouter } from 'react-router-dom';
 import './Settings.scss';
+import SettingsMenu from './Components/SettingsMenu';
 import SettingsConfirmation from './Components/SettingsConfirmation';
-import Switch from '@mui/material/Switch';
 
 class Settings extends React.Component{
     state = {
-        title: "Instellingen",
-        dutch: "",
-        english: "--inactive",
-        vibration: "Vibratie",
-        sound: "Geluid",
-        reset: "Opnieuw proberen",
-        icon_refresh_image_path: "/img/icon_refresh.png"
+        icon_cogwheel_image_path: "/img/icon_cogwheel.png",
+        settings_modal_state: false,
+        confirmation_modal_state: false
+    };
+
+    toggleComponent(name){
+        switch (name) {
+            case "settings_modal":
+                this.setState({settings_modal_state: !this.state.settings_modal_state});
+                break;
+            case "confirmation_modal":
+                this.setState({confirmation_modal_state: !this.state.confirmation_modal_state});
+                break;
+            default:
+                break;
+        }
+    }
+
+    settingsRestart(){
+        console.log("Change Route to restart");
     }
 
     render(){
         return(
-            <section class="settingsSection">
-                <SettingsConfirmation />
-                <h1 class="settingsSection__heading">{this.state.title}</h1>
-                <article class="settingsSection__languages">
-                    <button class={"settingsSection__languages__button button button--green" + this.state.dutch}>Nederlands</button>
-                    <button class={"settingsSection__languages__button button button--green" + this.state.english}>English</button>
-                </article>
-                <article class="settingsSection__toggles">
-                    <section class="settingsSection__toggles__toggleOption">
-                        <h2 class="settingsSection__toggles__toggleOption__text">{this.state.vibration}</h2>
-                        <Switch defaultChecked />
-                    </section>
-                    <hr class="settingsSection__toggles__hr" />
-                    <section class="settingsSection__toggles__toggleOption">
-                        <h2 class="settingsSection__toggles__toggleOption__text">{this.state.sound}</h2>
-                        <Switch defaultChecked />
-                    </section>
-                    
-                </article>
-                <button class="settingsSection__button button button--red">
-                    {this.state.reset}
-                    <img class="settingsSection__button__image" src={this.state.icon_refresh_image_path}/>
+            <section class="settings">
+                <button class="settings__button button--image" onClick={() => this.toggleComponent("settings_modal")}>
+                    <figure>
+                        <img class="settings__button__image" src={this.state.icon_cogwheel_image_path}></img>
+                    </figure>
                 </button>
+                {(this.state.confirmation_modal_state || this.state.settings_modal_state) && <div class="settings__modal">
+                {this.state.confirmation_modal_state && <SettingsConfirmation settingsRestart={this.settingsRestart.bind(this)} toggleComponent={this.toggleComponent.bind(this)} />}
+                {this.state.settings_modal_state && <SettingsMenu toggleComponent={this.toggleComponent.bind(this)}/>}   
+                </div>}
+
             </section>
         )
     }

--- a/geode-cracker/src/Settings/Settings.scss
+++ b/geode-cracker/src/Settings/Settings.scss
@@ -1,57 +1,28 @@
-.settingsSection{
-    min-width: 30rem;
-    max-width: 38rem;
-    margin: 0 auto;
-    padding: 1rem;
-
-    &__heading{
-        margin-bottom: 2rem;
-
-        text-align: center;
-        color: var(--white-color);
-        font-size: 3.4rem;
-        font-weight: 1000;
-    }
-
-    &__languages{
-        display: flex;
-        justify-content: space-between;
-        
-        margin-bottom: 4rem;
-
-        &__button{
-            width: 45%;
-            height: 4.6rem;
-        }
-    }
-
-    &__toggles{
-        margin-bottom:4rem;
-
-        &__toggleOption{
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-
-            &__text{
-                color: var(--white-color);
-                font-size: 2rem;
-            }
-        }
-
-        &__hr{
-            margin: 1rem 0;
-        }
-    }
+.settings{
 
     &__button{
-        width: 100%;
-        height: 4.6rem;
-
-        font-weight: 1000;
+        position: fixed;
+        top: 0;
+        right: 0;
+        z-index: 100;
+        
+        min-width: 8rem;
+        min-height: 8rem;
 
         &__image{
-            height: 2rem;
+            object-fit: cover;
         }
+    }
+
+    &__modal{
+        position: fixed;
+        top: 0;
+        z-index: 9;
+
+        width: 100vw;
+        height: 100vh;
+        padding-top: 20rem;
+
+        background: var(--background-color);
     }
 }

--- a/geode-cracker/src/index.scss
+++ b/geode-cracker/src/index.scss
@@ -97,3 +97,12 @@ h1, h2, h3{
   border: solid .2rem var(--inactive-red-color);
   background-color: transparent;
 }
+
+.button--image{
+  border: none;
+  background: transparent;
+}
+
+.button--image:hover{
+  cursor: pointer;
+}


### PR DESCRIPTION
# Features
- Settings.js code moved to SettingsMenu.js
- Settings.js now handles all Settings functionalities
- toggleComponent Function added inside Settings.js to handle show and hide of components
- settingsRestart Function added inside Settings.js to handle the restarting of the interaction (is called when the "yes" button inside the SettingsConfirmation component is called
# Code Snippets
![image](https://user-images.githubusercontent.com/74965312/206470833-c2653402-5b0e-475a-a5eb-7f56060de695.png)
![image](https://user-images.githubusercontent.com/74965312/206470129-5c73d418-d16c-4c4b-8809-0f4e4b361d5b.png)
![image](https://user-images.githubusercontent.com/74965312/206470364-a53bea9c-46b3-4e51-acde-b6cae6402f19.png)

# Feature Visuals
![image](https://user-images.githubusercontent.com/74965312/206469648-a765929e-53f3-4f98-854e-22d4bfa02cbd.png)
![image](https://user-images.githubusercontent.com/74965312/206469715-9bc3464f-da8f-4ce9-98b4-364b3d8f6a32.png)
