### PR TITLE
fix: settings popup language and polish.js action text

### DIFF
--- a/geode-cracker/src/Polish/Polish.js
+++ b/geode-cracker/src/Polish/Polish.js
@@ -90,12 +90,10 @@ class Polish extends React.Component{
       switch (this.state.interaction_state) {
         case "wash":
           this.setState({mascot_help_state: "wash"});
-          document.getElementById("action_text").innerHTML = this.state.wash_text;
           document.getElementById("bucket_img").style.visibility = "visible";
           break;
         case "polish":
           this.setState({mascot_help_state: "polish"});
-          document.getElementById("action_text").innerHTML = this.state.polish_text;
           document.getElementById("bucket_img").style.visibility = "hidden";
           for(var i = 0; i < document.getElementsByClassName("polish__section__figure__rock").length; i++) {
             document.getElementsByClassName("polish__section__figure__rock")[i].style.visibility = "hidden";
@@ -224,7 +222,9 @@ class Polish extends React.Component{
               <img class="polish__button__img" src={this.state.bucket_normal_image_path}></img>
             </button>
 
-            <h1 class="polish__text" id="action_text">{this.state.brush_text}</h1>
+            {this.state.mascot_help_state === "brush" && <h1 class="polish__text" id="action_text">{this.state.brush_text}</h1>}
+            {this.state.mascot_help_state === "wash" && <h1 class="polish__text" id="action_text">{this.state.wash_text}</h1>}
+            {this.state.mascot_help_state === "polish" && <h1 class="polish__text" id="action_text">{this.state.polish_text}</h1>}
 
             <section class="polish__section">
                 <figure class="polish__section__figure" onTouchStart={moveActiveObject} onTouchMove={moveActiveObject}>

--- a/geode-cracker/src/Settings/Components/SettingsConfirmation.js
+++ b/geode-cracker/src/Settings/Components/SettingsConfirmation.js
@@ -2,20 +2,27 @@ import React from 'react';
 import './SettingsConfirmation.scss'
 
 class SettingsConfirmation extends React.Component{
-    state = {
-        title: "Wil je opnieuw beginnen?",
-        text_button_left: "Nee",
-        text_button_right: "Ja"
-    }
-
     render(){
+        var title;
+        var text_button_left;
+        var text_button_right;
+        if(this.props.data_language == "NL"){
+            title = "Wil je opnieuw beginnen?";
+            text_button_left = "Nee";
+            text_button_right = "Ja";
+        } 
+        if(this.props.data_language == "EN"){
+            title = "Do you want to restart?";
+            text_button_left = "No";
+            text_button_right = "Yes";
+        }
         return(
             <section class="settingsConfirmation">
                 <article class="settingsConfirmation__modal">
-                    <h2 class="settingsConfirmation__modal__title">{this.state.title}</h2>
+                    <h2 class="settingsConfirmation__modal__title">{title}</h2>
                     <section class="settingsConfirmation__modal__choice">
-                        <button class="settingsConfirmation__modal__choice__button button button--green" onClick={() => this.props.toggleComponent("confirmation_modal")}>{this.state.text_button_left}</button>
-                        <button class="settingsConfirmation__modal__choice__button button button--red" onClick={() => {this.props.toggleComponent("confirmation_modal"); this.props.toggleComponent("settings_modal"); this.props.settingsRestart();}}>{this.state.text_button_right}</button>
+                        <button class="settingsConfirmation__modal__choice__button button button--green" onClick={() => this.props.toggleComponent("confirmation_modal")}>{text_button_left}</button>
+                        <button class="settingsConfirmation__modal__choice__button button button--red" onClick={() => {this.props.toggleComponent("confirmation_modal"); this.props.toggleComponent("settings_modal"); this.props.settingsRestart();}}>{text_button_right}</button>
                     </section>
                 </article>
             </section>

--- a/geode-cracker/src/Settings/Settings.js
+++ b/geode-cracker/src/Settings/Settings.js
@@ -37,7 +37,7 @@ class Settings extends React.Component{
                     </figure>
                 </button>
                 {(this.state.confirmation_modal_state || this.state.settings_modal_state) && <div class="settings__modal">
-                {this.state.confirmation_modal_state && <SettingsConfirmation settingsRestart={this.settingsRestart.bind(this)} toggleComponent={this.toggleComponent.bind(this)} />}
+                {this.state.confirmation_modal_state && <SettingsConfirmation data_language={this.props.data_language} settingsRestart={this.settingsRestart.bind(this)} toggleComponent={this.toggleComponent.bind(this)} />}
                 {this.state.settings_modal_state && <SettingsMenu data_language={this.props.data_language} settings_vibrations={this.props.settings_vibrations} updateLanguage={this.props.updateLanguage} toggleComponent={this.toggleComponent.bind(this)} updateSettings={this.props.updateSettings} />}   
                 </div>}
 


### PR DESCRIPTION
# Fixes
- Bug: Settings Popup for confirmation doesn't apply the active language
--> Fix: Settings.js now passes the language to SettingsConfirmation.js
--> SettingsConfirmation.js uses given language and applies it to the text
![image](https://user-images.githubusercontent.com/74965312/211412177-4187ed68-4441-44bf-b1b7-65b50cc6dc2b.png)
- Bug: Action text in polish.js reverts to brush action when changing languages
--> Fix: Action text in polish.js now changes to the correct action text based on the state of polish interaction
--> Polish.js uses it's mascot state to read the current interaction state and applies the correct action text
![image](https://user-images.githubusercontent.com/74965312/211412282-05e83bd6-8c14-4671-90d5-f223832df69c.png)
